### PR TITLE
Preparation for 0.9.0

### DIFF
--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -15,11 +15,14 @@ jdbc-default {
   url = "jdbc:postgresql://"${jdbc-default.host}":"${jdbc-default.port}"/"${jdbc-default.database}"?currentSchema="${jdbc-default.schema}
 
   hikari-settings {
-    #FIXME - add env vars for all these settings
     max-pool-size = 10
+    max-pool-size = ${?COS_DB_POOL_MAX_SIZE}
     min-idle-connections = 3
+    min-idle-connections = ${?COS_DB_POOL_IDLE_MIN_CONN_SIZE}
     idle-timeout-ms = 30000 # 30 seconds
+    idle-timeout-ms = ${?COS_DB_POOL_IDLE_TIMEOUT_MS}
     max-lifetime-ms = 60000 # 60 seconds
+    max-lifetime-ms = ${?COS_DB_POOL_MAX_LIFETIME_MS}
   }
 }
 
@@ -254,13 +257,6 @@ write-side-slick {
 
 jdbc-journal {
   tables {
-    # Only used in pre 5.0.0 for backward-compatibility
-    # ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
-    legacy_journal {
-      tableName = "journal"
-      schemaName = ${jdbc-default.schema}
-    }
-
     # this is the new going forward
     # ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
     event_journal {
@@ -300,7 +296,6 @@ jdbc-read-journal {
   # are delivered downstreams.
   max-buffer-size = "500"
   tables {
-    legacy_journal = ${jdbc-journal.tables.legacy_journal}
     event_journal = ${jdbc-journal.tables.event_journal}
     event_tag = ${jdbc-journal.tables.event_tag}
   }
@@ -310,13 +305,6 @@ jdbc-read-journal {
 # the akka-persistence-snapshot-store in use
 jdbc-snapshot-store {
   tables {
-    # Only used in pre 5.0.0 for backward-compatibility
-    # ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
-    legacy_snapshot {
-      tableName = "snapshot"
-      schemaName = ${jdbc-default.schema}
-    }
-
     # This is the new configuration going forward
     snapshot {
       tableName = "state_snapshot"
@@ -423,46 +411,5 @@ chiefofstate {
 
     trace_propagators = "b3multi"
     trace_propagators = ${?COS_TRACE_PROPAGATORS}
-  }
-
-  # migration configuration
-  # This setting are required for a smooth migration to 0.8.0
-  migration {
-    v1 {
-      slick {
-        profile = "slick.jdbc.PostgresProfile$"
-        # add here your Slick db settings
-        db {
-          driver = "org.postgresql.Driver"
-          user = ${jdbc-default.user}
-          user = ${?COS_READ_SIDE_OFFSET_DB_USER}
-          password = ${jdbc-default.password}
-          password = ${?COS_READ_SIDE_OFFSET_DB_PASSWORD}
-          serverName = ${jdbc-default.host}
-          serverName = ${?COS_READ_SIDE_OFFSET_DB_HOST}
-          portNumber = ${jdbc-default.port}
-          portNumber = ${?COS_READ_SIDE_OFFSET_DB_PORT}
-          databaseName = ${jdbc-default.database}
-          databaseName = ${?COS_READ_SIDE_OFFSET_DB}
-          url = "jdbc:postgresql://"${chiefofstate.migration.v1.slick.db.serverName}":"${chiefofstate.migration.v1.slick.db.portNumber}"/"${chiefofstate.migration.v1.slick.db.databaseName}"?currentSchema="${chiefofstate.migration.v1.slick.offset-store.schema}
-          connectionPool = "HikariCP"
-          keepAliveConnection = false
-          # See some tips on thread/connection pool sizing on https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
-          # Keep in mind that the number of threads must equal the maximum number of connections.
-          numThreads = 5
-          maxConnections = 5
-          minConnections = 0
-          idleTimeout = 60000 # 60 seconds
-          maxLifetime = 120000 # 120 seconds
-        }
-        offset-store {
-          schema = ${jdbc-default.schema}
-          schema = ${?COS_READ_SIDE_OFFSET_DB_SCHEMA}
-          table = "read_side_offsets"
-          table = ${?COS_READ_SIDE_OFFSET_STORE_TABLE}
-          use-lowercase-schema = false
-        }
-      }
-    }
   }
 }

--- a/code/service/src/main/scala/com/github/chiefofstate/ServiceMigrationRunner.scala
+++ b/code/service/src/main/scala/com/github/chiefofstate/ServiceMigrationRunner.scala
@@ -50,39 +50,11 @@ object ServiceMigrationRunner {
           // create and run the migrator
           val journalJdbcConfig: DatabaseConfig[JdbcProfile] =
             JdbcConfig.journalConfig(config)
-
-          // for the migration, as COS projections has moved to raw JDBC
-          // connections and no longer uses slick.
-          val projectionJdbcConfig: DatabaseConfig[JdbcProfile] =
-            JdbcConfig.projectionConfig(config)
-
-          // get the projection config
-          val priorProjectionJdbcConfig: DatabaseConfig[JdbcProfile] =
-            JdbcConfig.projectionConfig(config, "chiefofstate.migration.v1.slick")
-
-          // get the old table name
-          val priorOffsetStoreName: String =
-            config.getString("chiefofstate.migration.v1.slick.offset-store.table")
-
           val schema: String = config.getString("jdbc-default.schema")
-
-          val v1: V1 = V1(journalJdbcConfig, priorProjectionJdbcConfig, priorOffsetStoreName)
-          val v2: V2 = V2(journalJdbcConfig, projectionJdbcConfig)(context.system)
-          val v3: V3 = V3(journalJdbcConfig)
-          val v4: V4 = V4(journalJdbcConfig)
-          val v5: V5 = V5(context.system, journalJdbcConfig)
           val v6: V6 = V6(journalJdbcConfig)
-
           // instance of the migrator
           val migrator: Migrator =
-            new Migrator(journalJdbcConfig, schema)
-              .addVersion(v1)
-              .addVersion(v2)
-              .addVersion(v3)
-              .addVersion(v4)
-              .addVersion(v5)
-              .addVersion(v6)
-
+            new Migrator(journalJdbcConfig, schema).addVersion(v6)
           migrator.run()
         }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,10 @@ See the following deployment-specific guides for relevant configurations:
 | COS_DB_PORT | journal, snapshot and read side offsets store port | 5432 |
 | COS_DB_NAME | journal, snapshot and read side offsets store db name | postgres |
 | COS_DB_SCHEMA | journal, snapshot and read side offsets store db schema | public |
+| COS_DB_POOL_MAX_SIZE | determines the maximum number of actual connections to the COS database | 10 |
+| COS_DB_POOL_IDLE_MIN_CONN_SIZE | controls the minimum number of idle connections to maintain in the pool | 3 |
+| COS_DB_POOL_IDLE_TIMEOUT_MS | controls the maximum amount of time in milliseconds that a connection is allowed to sit idle in the pool | 30000 |
+| COS_DB_POOL_MAX_LIFETIME_MS | controls the maximum lifetime in milliseconds of a connection in the pool | 60000 |
 | COS_SNAPSHOT_FREQUENCY |Save snapshots automatically every Number of Events| 100 |
 | COS_NUM_SNAPSHOTS_TO_RETAIN | Number of Aggregate Snapshot to persist to disk for swift recovery | 2 |
 | COS_READ_SIDE_ENABLED | turn on readside or not | false |


### PR DESCRIPTION
- Remove the legacy storage migration config
- Remove code that run migration prior to migration v6